### PR TITLE
Replace 'fail' with 'throwM'

### DIFF
--- a/bimap.cabal
+++ b/bimap.cabal
@@ -25,7 +25,7 @@ extra-source-files:
     Test/RunTests.hs
 
 Library
-  build-depends:       base >= 4 && <5, containers
+  build-depends:       base >= 4 && <5, containers, exceptions
   ghc-options:         -Wall
   exposed-modules:
       Data.Bimap


### PR DESCRIPTION
Would you please consider replacing this infamous `fail` with a cleaner `throwM` ? :)
