### PR TITLE
bimap.cabal: add missing files to cabal test suite

### DIFF
--- a/bimap.cabal
+++ b/bimap.cabal
@@ -28,6 +28,8 @@ Library
 test-suite tests
     type:            exitcode-stdio-1.0
     main-is:         Test/RunTests.hs
+    other-modules:   Test.Tests
+                     Test.Util
     build-depends:   base >= 4 && < 5,
                      containers,
                      exceptions,


### PR DESCRIPTION
Detected when packaged in gentoo:

  Preprocessing test suite 'tests' for bimap-0.3.1...

  Test/RunTests.hs:9:8:
    Could not find module ‘Test.Tests’

Signed-off-by: Sergei Trofimovich siarheit@google.com
