### PR TITLE
Aesthetic changes: add (!?) and (!?>) operators + some docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle

--- a/Data/Bimap.hs
+++ b/Data/Bimap.hs
@@ -36,6 +36,8 @@ module Data.Bimap (
     lookupR,
     (!),
     (!>),
+    (!?),
+    (!?>),
     -- * Construction
     empty,
     singleton,
@@ -378,6 +380,12 @@ and returns the corresponding left key.
 /Version: 0.2/-}
 (!>) :: (Ord a, Ord b) => Bimap a b -> b -> a
 (!>) bi y = fromMaybe (error "Data.Bimap.(!>): Right key not found") $ lookupR y bi
+
+(!?) :: (Ord a, Ord b, MonadThrow m) => a -> Bimap a b -> m b
+(!?) = lookup
+
+(!?>) :: (Ord a, Ord b, MonadThrow m) => b -> Bimap a b -> m a
+(!?>) = lookupR
 
 {-| /O(n*log n)/.
 Build a map from a list of pairs. If there are any overlapping

--- a/Data/Bimap.hs
+++ b/Data/Bimap.hs
@@ -381,9 +381,13 @@ and returns the corresponding left key.
 (!>) :: (Ord a, Ord b) => Bimap a b -> b -> a
 (!>) bi y = fromMaybe (error "Data.Bimap.(!>): Right key not found") $ lookupR y bi
 
+{-| /O(log n)/.
+See 'lookup'. -}
 (!?) :: (Ord a, Ord b, MonadThrow m) => a -> Bimap a b -> m b
 (!?) = lookup
 
+{-| /O(log n)/.
+See 'lookupR'. -}
 (!?>) :: (Ord a, Ord b, MonadThrow m) => b -> Bimap a b -> m a
 (!?>) = lookupR
 

--- a/Data/Bimap.hs
+++ b/Data/Bimap.hs
@@ -388,13 +388,13 @@ and returns the corresponding left key.
 
 {-| /O(log n)/.
 See 'lookup'. -}
-(!?) :: (Ord a, Ord b, MonadThrow m) => a -> Bimap a b -> m b
-(!?) = lookup
+(!?) :: (Ord a, Ord b, MonadThrow m) => Bimap a b -> a -> m b
+(!?) = flip lookup
 
 {-| /O(log n)/.
 See 'lookupR'. -}
-(!?>) :: (Ord a, Ord b, MonadThrow m) => b -> Bimap a b -> m a
-(!?>) = lookupR
+(!?>) :: (Ord a, Ord b, MonadThrow m) => Bimap a b -> b -> m a
+(!?>) = flip lookupR
 
 {-| /O(n*log n)/.
 Build a map from a list of pairs. If there are any overlapping

--- a/Data/Bimap.hs
+++ b/Data/Bimap.hs
@@ -348,6 +348,9 @@ Lookup a left key in the bimap, returning the associated right key.
 This function will @return@ the result in the monad, or @fail@ if
 the value isn't in the bimap.
 
+Note that the signature differs slightly from Data.Map's @lookup@. This one is more general -
+it functions the same way as the "original" if @m@ is cast (or inferred) to Maybe.
+
 /Version: 0.2/-}
 lookup :: (Ord a, Ord b, MonadThrow m)
        => a -> Bimap a b -> m b
@@ -359,6 +362,8 @@ lookup x (MkBimap left _) =
 {-| /O(log n)/.
 A version of 'lookup' that is specialized to the right key,
 and returns the corresponding left key.
+
+
 /Version: 0.2/-}
 lookupR :: (Ord a, Ord b, MonadThrow m)
         => b -> Bimap a b -> m a


### PR DESCRIPTION
As the title suggests:
- Two new operators (!?) and (!?>) which correspond to `flip lookup` and `flip lookupR`.
- *Really minimal* documentation for those two.
- `lookup` note that mentions how this lookup compares to the Data.Map's `lookup` function.

The last one is important, I think, because it wasn't immediately obvious (for me :) )
that MonadThrow *includes* Maybe and `lookup` works the same way as Data.Map's `lookup` if `m` is Maybe. 
Added this bit in the docs "for educational purposes", basically.

Again, really small change, but I think it'd make the library just this much nicer.