### PR TITLE
Introduce intermediate module that re-exports GHC.Exts.IsList. Close #14.

### DIFF
--- a/Data/Bimap.hs
+++ b/Data/Bimap.hs
@@ -105,7 +105,7 @@ import           Data.Maybe          (fromMaybe)
 import           Data.Typeable
 
 #if __GLASGOW_HASKELL__ >= 708
-import qualified GHC.Exts            as GHCExts
+import qualified Data.BimapExt       as GHCExts
 #endif
 import           GHC.Generics        (Generic)
 

--- a/Data/BimapExt.hs
+++ b/Data/BimapExt.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE Trustworthy #-}
+{-|
+An auxiliary module that exports the 'IsList' class from "GHC.Exts". We use
+this intermediate module to isolate a safe feature from an otherwise non-safe
+module, and prevent all of "Data.Bimap" from being marked as not safe just
+because we are importing "GHC.Exts".
+
+The module only exports a class, and the class does not define any methods in
+an unsafe way. We therefore consider it safe and mark this module as
+trustworthy.
+-}
+module Data.BimapExt (
+    IsList(..)
+) where
+
+import GHC.Exts (IsList(..))

--- a/bimap.cabal
+++ b/bimap.cabal
@@ -27,6 +27,10 @@ Library
   exposed-modules:
       Data.Bimap
 
+  if impl(ghc >= 7.8)
+    other-modules:
+      Data.BimapExt
+
 test-suite tests
     type:            exitcode-stdio-1.0
     main-is:         Test/RunTests.hs


### PR DESCRIPTION
Data.Bimap currently uses IsList, which is imported from GHC.Exts.
Because GHC.Exts is itself not safe, GHC infers that Data.Bimap isn't
safe either. This prevents other libraries from using Bimap from safe
modules unless they trust the bimap package completely.

This commit introduces an intermediate Data.BimapExt module that imports
and re-exports GHC.Exts.IsList. The new module is marked as trustworthy,
which is a reasonable assesment given that the class definition is safe
(only one method is pre-defined, and it is defined in a safe way).

Data.Bimap now imports that new, trustworthy module instead of importing
GHC.Exts directly, which allows GHC to infer that Data.Bimap is safe.